### PR TITLE
Ktlint config is applied only to kotlin (kt, kts) files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,6 +1,6 @@
 root = true
 
-[*]
+[*.{kt, kts}]
 end_of_line = lf
 insert_final_newline = true
 indent_size = 4

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,6 +1,6 @@
 root = true
 
-[*.{kt, kts}]
+[*.{kt,kts}]
 end_of_line = lf
 insert_final_newline = true
 indent_size = 4


### PR DESCRIPTION
`.editorconfig` filters can be defined for the particular file extension (`[*.{kt,kts}]`) instead of the whole file.

The `.editorconfig` parser is imperfect, so, for now, we have to make sure there is no space between extensions
https://github.com/JLLeitschuh/ktlint-gradle/issues/269

The parser will be replaced at some point
https://github.com/pinterest/ktlint/pull/561