### PR TITLE
Retrieve dynamic module names from gradle module list

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -13,12 +13,6 @@ plugins {
 android {
     compileSdkVersion(AndroidConfig.COMPILE_SDK_VERSION)
 
-    val featureModules = setOf(
-        ModuleDependency.FEATURE_ALBUM,
-        ModuleDependency.FEATURE_FAVOURITE,
-        ModuleDependency.FEATURE_PROFILE
-    )
-
     defaultConfig {
         applicationId = AndroidConfig.ID
         minSdkVersion(AndroidConfig.MIN_SDK_VERSION)
@@ -33,8 +27,7 @@ android {
         buildConfigFieldFromGradleProperty("apiBaseUrl")
         buildConfigFieldFromGradleProperty("apiToken")
 
-        val featureModuleNames = featureModules.map { it.removePrefix(":feature_") }
-        buildConfigField("FEATURE_MODULE_NAMES", featureModuleNames)
+        buildConfigField("FEATURE_MODULE_NAMES", getDynamicFeatureModuleNames())
     }
 
     buildTypes {
@@ -57,8 +50,8 @@ android {
         }
     }
 
-    dynamicFeatures = featureModules.toMutableSet()
-
+    // Each feature module that is included in settings.gradle.kts is added here as dynamic feature
+    dynamicFeatures = getDynamicFeatureModules().toMutableSet()
 
     lintOptions {
         // By default lint does not check test sources, but setting this option means that lint will nto even parse them
@@ -104,6 +97,12 @@ dependencies {
 
     addTestDependencies()
 }
+
+fun getDynamicFeatureModules() = rootProject.subprojects
+    .map { ":${it.name}" }
+    .filter { it.startsWith(":feature_") }
+
+fun getDynamicFeatureModuleNames() = getDynamicFeatureModules().map { it.removePrefix(":feature_") }
 
 fun BaseFlavor.buildConfigFieldFromGradleProperty(gradlePropertyName: String) {
     val propertyValue = project.properties[gradlePropertyName] as? String

--- a/app/src/main/java/com/igorwojda/showcase/app/feature/FeatureManager.kt
+++ b/app/src/main/java/com/igorwojda/showcase/app/feature/FeatureManager.kt
@@ -1,5 +1,6 @@
 package com.igorwojda.showcase.app.feature
 
+import com.igorwojda.showcase.BuildConfig
 import com.igorwojda.showcase.app.feature.gateway.KodeinModuleProvider
 
 // Dynamic Feature modules require reversed dependency (dynamic feature module depends on app module)
@@ -9,11 +10,17 @@ import com.igorwojda.showcase.app.feature.gateway.KodeinModuleProvider
 object FeatureManager {
 
     private const val featurePackagePrefix = "com.igorwojda.showcase.feature"
-    private val featureNames = listOf("album", "favourite", "profile")
+    private val featureNames = BuildConfig.FEATURE_MODULE_NAMES
 
     val kodeinModules = featureNames
         .map { "$featurePackagePrefix.$it.FeatureKodeinModule" }
-        .map { Class.forName(it).kotlin.objectInstance }
+        .map {
+            try {
+                Class.forName(it).kotlin.objectInstance
+            } catch (e: ClassNotFoundException) {
+                throw RuntimeException("Kodein module not found $it")
+            }
+        }
         .map { it as KodeinModuleProvider }
         .map { it.kodeinModule }
 }

--- a/app/src/main/java/com/igorwojda/showcase/app/feature/FeatureManager.kt
+++ b/app/src/main/java/com/igorwojda/showcase/app/feature/FeatureManager.kt
@@ -18,7 +18,7 @@ object FeatureManager {
             try {
                 Class.forName(it).kotlin.objectInstance
             } catch (e: ClassNotFoundException) {
-                throw RuntimeException("Kodein module not found $it")
+                throw ClassNotFoundException("Kodein module class not found $it")
             }
         }
         .map { it as KodeinModuleProvider }


### PR DESCRIPTION
This way after adding a new module to `settings.gradle.kts` there is no need to modify `dynamicFeatures` and `buildConfigField` (module names are propagated from Gradle into Android configuration)