### PR TITLE
Retrieve module names from ModuleDependency object

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,3 +1,4 @@
+
 import com.android.build.gradle.internal.dsl.BaseFlavor
 import com.android.build.gradle.internal.dsl.DefaultConfig
 import org.jetbrains.kotlin.gradle.dsl.KotlinJvmOptions
@@ -51,12 +52,11 @@ android {
     }
 
     // Each feature module that is included in settings.gradle.kts is added here as dynamic feature
-    dynamicFeatures = getDynamicFeatureModules().toMutableSet()
+    dynamicFeatures = ModuleDependency.getDynamicFeatureModules().toMutableSet()
 
     lintOptions {
-        // By default lint does not check test sources, but setting this option means that lint will nto even parse them
+        // By default lint does not check test sources, but setting this option means that lint will not even parse them
         isIgnoreTestSources = true
-        val b = ModuleDependency.a
     }
 
     compileOptions {
@@ -99,12 +99,6 @@ dependencies {
     addTestDependencies()
 }
 
-fun getDynamicFeatureModules() = rootProject.subprojects
-    .map { ":${it.name}" }
-    .filter { it.startsWith(":feature_") }
-
-fun getDynamicFeatureModuleNames() = getDynamicFeatureModules().map { it.removePrefix(":feature_") }
-
 fun BaseFlavor.buildConfigFieldFromGradleProperty(gradlePropertyName: String) {
     val propertyValue = project.properties[gradlePropertyName] as? String
     checkNotNull(propertyValue) { "Gradle property $gradlePropertyName is null" }
@@ -113,9 +107,13 @@ fun BaseFlavor.buildConfigFieldFromGradleProperty(gradlePropertyName: String) {
     buildConfigField("String", androidResourceName, propertyValue)
 }
 
+fun getDynamicFeatureModuleNames() = ModuleDependency.getDynamicFeatureModules()
+    .map { it.replace(":feature_", "") }
+    .toSet()
+
 fun String.toSnakeCase() = this.split(Regex("(?=[A-Z])")).joinToString("_") { it.toLowerCase() }
 
-fun DefaultConfig.buildConfigField(name: String, value: List<String>) {
+fun DefaultConfig.buildConfigField(name: String, value: Set<String>) {
     // Generates String that holds Java String Array code
     val strValue = value.joinToString(prefix = "{", separator = ",", postfix = "}", transform = { "\"$it\"" })
     buildConfigField("String[]", name, strValue)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -56,6 +56,7 @@ android {
     lintOptions {
         // By default lint does not check test sources, but setting this option means that lint will nto even parse them
         isIgnoreTestSources = true
+        val b = ModuleDependency.a
     }
 
     compileOptions {

--- a/app/src/main/java/com/igorwojda/showcase/app/feature/FeatureManager.kt
+++ b/app/src/main/java/com/igorwojda/showcase/app/feature/FeatureManager.kt
@@ -11,7 +11,7 @@ object FeatureManager {
     private const val featurePackagePrefix = "com.igorwojda.showcase.feature"
 
     val kodeinModules = BuildConfig.FEATURE_MODULE_NAMES
-        .map { "$featurePackagePrefix.$it.FeatureKodeinModule" }  // feature.x -> com.igorwojda.showcase.feature.x
+        .map { "$featurePackagePrefix.$it.FeatureKodeinModule" }
         .map {
             try {
                 Class.forName(it).kotlin.objectInstance as KodeinModuleProvider

--- a/app/src/main/java/com/igorwojda/showcase/app/feature/FeatureManager.kt
+++ b/app/src/main/java/com/igorwojda/showcase/app/feature/FeatureManager.kt
@@ -9,17 +9,15 @@ import com.igorwojda.showcase.BuildConfig
 object FeatureManager {
 
     private const val featurePackagePrefix = "com.igorwojda.showcase.feature"
-    private val featureNames = BuildConfig.FEATURE_MODULE_NAMES
 
-    val kodeinModules = featureNames
-        .map { "$featurePackagePrefix.$it.FeatureKodeinModule" }
+    val kodeinModules = BuildConfig.FEATURE_MODULE_NAMES
+        .map { "$featurePackagePrefix.$it.FeatureKodeinModule" }  // feature.x -> com.igorwojda.showcase.feature.x
         .map {
             try {
-                Class.forName(it).kotlin.objectInstance
+                Class.forName(it).kotlin.objectInstance as KodeinModuleProvider
             } catch (e: ClassNotFoundException) {
                 throw ClassNotFoundException("Kodein module class not found $it")
             }
         }
-        .map { it as KodeinModuleProvider }
         .map { it.kodeinModule }
 }

--- a/buildSrc/src/main/kotlin/ModuleDependency.kt
+++ b/buildSrc/src/main/kotlin/ModuleDependency.kt
@@ -11,8 +11,8 @@ object ModuleDependency {
     const val LIBRARY_BASE = ":library_base"
     const val LIBRARY_TEST_UTILS = ":library_test_utils"
 
-    // There is no easy way to retrieve dynamic feature modules from gradle based on plugin type
-    // ("com.android.dynamic-feature") but we can retrieve them from above consts via reflection
+    // Unused function false positive
+    // See: https://youtrack.jetbrains.com/issue/KT-33610
     fun getAllModules() = ModuleDependency::class.memberProperties
         .filter { it.isConst }
         .map { it.getter.call().toString() }

--- a/buildSrc/src/main/kotlin/ModuleDependency.kt
+++ b/buildSrc/src/main/kotlin/ModuleDependency.kt
@@ -1,24 +1,8 @@
 import kotlin.reflect.full.memberProperties
 
-const val FEATURE_PREFIX = ":feature_"
+private const val FEATURE_PREFIX = ":feature_"
 
 // "Module" means "project" in terminology of Gradle API. To be specific each "Android module" is a Gradle "subproject".
-
-// enum class ModuleDependency(val moduleName: String) {
-//     APP(":app"),
-//     FEATURE_ALBUM(":feature_album"),
-//     FEATURE_PROFILE(":feature_profile"),
-//     FEATURE_FAVOURITE(":feature_favourite"),
-//     LIBRARY_BASE(":library_base"),
-//     LIBRARY_TEST_UTILS(":library_test_utils");
-//
-//     // There is no easy way to retrieve dynamic feature modules from gradle based on plugin type ("com.android.dynamic-feature",
-//     // so we have to retrieve them from enum
-//     fun getDynamicFeatures() = enumValues<ModuleDependency>().filter { it.moduleName.startsWith(FEATURE_PREFIX) }
-//
-//     fun getAll() = enumValues<ModuleDependency>()
-// }
-
 object ModuleDependency {
     const val APP = ":app"
     const val FEATURE_ALBUM = ":feature_album"
@@ -27,18 +11,14 @@ object ModuleDependency {
     const val LIBRARY_BASE = ":library_base"
     const val LIBRARY_TEST_UTILS = ":library_test_utils"
 
-    val a = ModuleDependency::class.memberProperties.forEach { println(it) }
-    // map { it.getter.call(ModuleDependency::class.objectInstance).toString() }
+    // There is no easy way to retrieve dynamic feature modules from gradle based on plugin type ("com.android.dynamic-feature")
+    // but we can retrieve them from above consts via reflection
+    fun getAllModules() = ModuleDependency::class.memberProperties
+        .filter { it.isConst }
+        .map { it.getter.call().toString() }
+        .toSet()
 
-    val dynamicFeatureModules = setOf(
-        ModuleDependency.FEATURE_ALBUM,
-        ModuleDependency.FEATURE_FAVOURITE,
-        ModuleDependency.FEATURE_PROFILE
-    )
-
-    val modules = setOf(
-        ModuleDependency.FEATURE_ALBUM,
-        ModuleDependency.FEATURE_FAVOURITE,
-        ModuleDependency.FEATURE_PROFILE
-    )
+    fun getDynamicFeatureModules() = getAllModules()
+        .filter { it.startsWith(FEATURE_PREFIX) }
+        .toSet()
 }

--- a/buildSrc/src/main/kotlin/ModuleDependency.kt
+++ b/buildSrc/src/main/kotlin/ModuleDependency.kt
@@ -1,3 +1,24 @@
+import kotlin.reflect.full.memberProperties
+
+const val FEATURE_PREFIX = ":feature_"
+
+// "Module" means "project" in terminology of Gradle API. To be specific each "Android module" is a Gradle "subproject".
+
+// enum class ModuleDependency(val moduleName: String) {
+//     APP(":app"),
+//     FEATURE_ALBUM(":feature_album"),
+//     FEATURE_PROFILE(":feature_profile"),
+//     FEATURE_FAVOURITE(":feature_favourite"),
+//     LIBRARY_BASE(":library_base"),
+//     LIBRARY_TEST_UTILS(":library_test_utils");
+//
+//     // There is no easy way to retrieve dynamic feature modules from gradle based on plugin type ("com.android.dynamic-feature",
+//     // so we have to retrieve them from enum
+//     fun getDynamicFeatures() = enumValues<ModuleDependency>().filter { it.moduleName.startsWith(FEATURE_PREFIX) }
+//
+//     fun getAll() = enumValues<ModuleDependency>()
+// }
+
 object ModuleDependency {
     const val APP = ":app"
     const val FEATURE_ALBUM = ":feature_album"
@@ -5,4 +26,19 @@ object ModuleDependency {
     const val FEATURE_FAVOURITE = ":feature_favourite"
     const val LIBRARY_BASE = ":library_base"
     const val LIBRARY_TEST_UTILS = ":library_test_utils"
+
+    val a = ModuleDependency::class.memberProperties.forEach { println(it) }
+    // map { it.getter.call(ModuleDependency::class.objectInstance).toString() }
+
+    val dynamicFeatureModules = setOf(
+        ModuleDependency.FEATURE_ALBUM,
+        ModuleDependency.FEATURE_FAVOURITE,
+        ModuleDependency.FEATURE_PROFILE
+    )
+
+    val modules = setOf(
+        ModuleDependency.FEATURE_ALBUM,
+        ModuleDependency.FEATURE_FAVOURITE,
+        ModuleDependency.FEATURE_PROFILE
+    )
 }

--- a/buildSrc/src/main/kotlin/ModuleDependency.kt
+++ b/buildSrc/src/main/kotlin/ModuleDependency.kt
@@ -2,7 +2,7 @@ import kotlin.reflect.full.memberProperties
 
 private const val FEATURE_PREFIX = ":feature_"
 
-// "Module" means "project" in terminology of Gradle API. To be specific each "Android module" is a Gradle "subproject".
+// "Module" means "project" in terminology of Gradle API. To be specific each "Android module" is a Gradle "subproject"
 object ModuleDependency {
     const val APP = ":app"
     const val FEATURE_ALBUM = ":feature_album"
@@ -11,8 +11,8 @@ object ModuleDependency {
     const val LIBRARY_BASE = ":library_base"
     const val LIBRARY_TEST_UTILS = ":library_test_utils"
 
-    // There is no easy way to retrieve dynamic feature modules from gradle based on plugin type ("com.android.dynamic-feature")
-    // but we can retrieve them from above consts via reflection
+    // There is no easy way to retrieve dynamic feature modules from gradle based on plugin type
+    // ("com.android.dynamic-feature") but we can retrieve them from above consts via reflection
     fun getAllModules() = ModuleDependency::class.memberProperties
         .filter { it.isConst }
         .map { it.getter.call().toString() }

--- a/library_base/src/main/java/com/igorwojda/showcase/library/base/presentation/viewmodel/StateTimeTravelDebugger.kt
+++ b/library_base/src/main/java/com/igorwojda/showcase/library/base/presentation/viewmodel/StateTimeTravelDebugger.kt
@@ -68,9 +68,9 @@ class StateTimeTravelDebugger(private val viewClassName: String) {
     }
 
     private fun getPropertyValue(baseViewState: BaseViewState, propertyName: String): String {
-        baseViewState::class.memberProperties.forEach { kCallable ->
-            if (propertyName == kCallable.name) {
-                var value = kCallable.getter.call(baseViewState).toString()
+        baseViewState::class.memberProperties.forEach {
+            if (propertyName == it.name) {
+                var value = it.getter.call(baseViewState).toString()
 
                 if (value.isBlank()) {
                     value = "\"\""

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,10 +1,3 @@
 rootProject.buildFileName = "build.gradle.kts"
 
-include(
-    ModuleDependency.APP,
-    ModuleDependency.FEATURE_ALBUM,
-    ModuleDependency.FEATURE_PROFILE,
-    ModuleDependency.FEATURE_FAVOURITE,
-    ModuleDependency.LIBRARY_BASE,
-    ModuleDependency.LIBRARY_TEST_UTILS
-)
+include(*ModuleDependency.getAllModules().toTypedArray())


### PR DESCRIPTION
All the modules are defined once in the `ModuleDependency` and passed across various places in the build script:
- Gradle configuration defining a list of Gradle modules/subprojects (`gradle.settings.kts`)
- Android dynamic feature list (`app\build.gradle.kts`)
- Android build config module names list (`app\build.gradle.kts`)
