### PR TITLE
Drop usage of buildscript dependencies classpath.

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,4 +1,3 @@
-
 import com.android.build.gradle.internal.dsl.BaseFlavor
 import com.android.build.gradle.internal.dsl.DefaultConfig
 import org.jetbrains.kotlin.gradle.dsl.KotlinJvmOptions

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,30 +2,17 @@ import com.github.benmanes.gradle.versions.updates.DependencyUpdatesTask
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import org.jlleitschuh.gradle.ktlint.reporter.ReporterType
 
-buildscript {
-    repositories {
-        // Android plugin & support libraries
-        google()
-
-        // Main open-source repository
-        jcenter()
-
-        // Ktlint Gradle
-        maven("https://plugins.gradle.org/m2/")
-    }
-
-    dependencies {
-        classpath(GradleDependency.ANDROID_GRADLE)
-        classpath(GradleDependency.KOTLIN)
-        classpath(GradleDependency.SAFE_ARGS)
-        classpath(GradleDependency.KTLINT_GRADLE)
-    }
-}
-
 plugins {
-    id(GradlePluginId.DETEKT) version GradlePluginVersion.DETEKT
-    id(GradlePluginId.KTLINT_GRADLE) version GradlePluginVersion.KTLINT_GRADLE
-    id(GradlePluginId.GRADLE_VERSION_PLUGIN) version GradlePluginVersion.GRADLE_VERSION_PLUGIN
+    id(GradlePluginId.DETEKT)
+    id(GradlePluginId.KTLINT_GRADLE)
+    id(GradlePluginId.GRADLE_VERSION_PLUGIN)
+    id(GradlePluginId.KOTLIN_JVM) apply false
+    id(GradlePluginId.KOTLIN_ANDROID) apply false
+    id(GradlePluginId.KOTLIN_ANDROID_EXTENSIONS) apply false
+    id(GradlePluginId.ANDROID_APPLICATION) apply false
+    id(GradlePluginId.ANDROID_DYNAMIC_FEATURE) apply false
+    id(GradlePluginId.ANDROID_LIBRARY) apply false
+    id(GradlePluginId.SAFE_ARGS) apply false
 }
 
 // all projects = root project + sub projects
@@ -36,7 +23,7 @@ allprojects {
     }
 
     // We want to apply ktlint at all project level because it also checks build gradle files
-    plugins.apply(GradlePluginId.KTLINT_GRADLE)
+    apply(plugin = GradlePluginId.KTLINT_GRADLE)
 
     // Ktlint configuration for sub-projects
     ktlint {
@@ -56,7 +43,7 @@ subprojects {
         maxParallelForks = (Runtime.getRuntime().availableProcessors() / 2).takeIf { it > 0 } ?: 1
     }
 
-    plugins.apply(GradlePluginId.DETEKT)
+    apply(plugin = GradlePluginId.DETEKT)
 
     detekt {
         config = files("${project.rootDir}/config/detekt.yml")

--- a/buildSrc/src/main/kotlin/GradleDependency.kt
+++ b/buildSrc/src/main/kotlin/GradleDependency.kt
@@ -3,6 +3,8 @@ object GradlePluginVersion {
     const val KTLINT_GRADLE = "8.2.0"
     const val DETEKT = "1.0.1"
     const val GRADLE_VERSION_PLUGIN = "0.22.0"
+    const val KOTLIN = CoreVersion.KOTLIN
+    const val SAFE_ARGS = CoreVersion.NAVIGATION
 }
 
 object GradlePluginId {
@@ -11,15 +13,14 @@ object GradlePluginId {
     const val ANDROID_APPLICATION = "com.android.application"
     const val ANDROID_DYNAMIC_FEATURE = "com.android.dynamic-feature"
     const val ANDROID_LIBRARY = "com.android.library"
+    const val KOTLIN_JVM = "org.jetbrains.kotlin.jvm"
     const val KOTLIN_ANDROID = "org.jetbrains.kotlin.android"
-    const val KOTLIN_ANDROID_EXTENSIONS = "kotlin-android-extensions"
+    const val KOTLIN_ANDROID_EXTENSIONS = "org.jetbrains.kotlin.android.extensions"
     const val GRADLE_VERSION_PLUGIN = "com.github.ben-manes.versions"
     const val SAFE_ARGS = "androidx.navigation.safeargs.kotlin"
 }
 
-object GradleDependency {
-    const val KOTLIN = "org.jetbrains.kotlin:kotlin-gradle-plugin:${CoreVersion.KOTLIN}"
+object GradleOldWayPlugins {
     const val ANDROID_GRADLE = "com.android.tools.build:gradle:${GradlePluginVersion.ANDROID_GRADLE}"
-    const val KTLINT_GRADLE = "org.jlleitschuh.gradle:ktlint-gradle:${GradlePluginVersion.KTLINT_GRADLE}"
-    const val SAFE_ARGS = "androidx.navigation:navigation-safe-args-gradle-plugin:${CoreVersion.NAVIGATION}"
+    const val SAFE_ARGS = "androidx.navigation:navigation-safe-args-gradle-plugin:${GradlePluginVersion.SAFE_ARGS}"
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,3 +1,33 @@
-rootProject.buildFileName = "build.gradle.kts"
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        google()
+    }
 
+    plugins {
+        id(GradlePluginId.DETEKT) version GradlePluginVersion.DETEKT
+        id(GradlePluginId.KTLINT_GRADLE) version GradlePluginVersion.KTLINT_GRADLE
+        id(GradlePluginId.GRADLE_VERSION_PLUGIN) version GradlePluginVersion.GRADLE_VERSION_PLUGIN
+        id(GradlePluginId.KOTLIN_JVM) version GradlePluginVersion.KOTLIN
+        id(GradlePluginId.KOTLIN_ANDROID) version GradlePluginVersion.KOTLIN
+        id(GradlePluginId.KOTLIN_ANDROID_EXTENSIONS) version GradlePluginVersion.KOTLIN
+        id(GradlePluginId.ANDROID_APPLICATION) version GradlePluginVersion.ANDROID_GRADLE
+        id(GradlePluginId.ANDROID_LIBRARY) version GradlePluginVersion.ANDROID_GRADLE
+        id(GradlePluginId.ANDROID_DYNAMIC_FEATURE) version GradlePluginVersion.ANDROID_GRADLE
+        id(GradlePluginId.SAFE_ARGS) version GradlePluginVersion.SAFE_ARGS
+    }
+
+    resolutionStrategy {
+        eachPlugin {
+            when (requested.id.id) {
+                GradlePluginId.ANDROID_APPLICATION,
+                GradlePluginId.ANDROID_LIBRARY,
+                GradlePluginId.ANDROID_DYNAMIC_FEATURE -> useModule(GradleOldWayPlugins.ANDROID_GRADLE)
+                GradlePluginId.SAFE_ARGS -> useModule(GradleOldWayPlugins.SAFE_ARGS)
+            }
+        }
+    }
+}
+
+rootProject.buildFileName = "build.gradle.kts"
 include(*ModuleDependency.getAllModules().toTypedArray())


### PR DESCRIPTION
Use new way of requesting the plugins and plugins version management introduced in Gradle 5.6 release.
