### PR TITLE
Updated LiveData observe

### DIFF
--- a/feature_album/src/main/java/com/igorwojda/showcase/feature/album/presentation/albumdetail/AlbumDetailFragment.kt
+++ b/feature_album/src/main/java/com/igorwojda/showcase/feature/album/presentation/albumdetail/AlbumDetailFragment.kt
@@ -2,6 +2,7 @@ package com.igorwojda.showcase.feature.album.presentation.albumdetail
 
 import android.os.Bundle
 import android.view.View
+import androidx.lifecycle.Observer
 import coil.api.load
 import com.igorwojda.showcase.feature.album.R
 import com.igorwojda.showcase.library.base.presentation.extension.observe
@@ -16,28 +17,28 @@ internal class AlbumDetailFragment : BaseContainerFragment() {
 
     override val layoutResourceId = R.layout.fragment_album_detail
 
-    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        super.onViewCreated(view, savedInstanceState)
+    private val stateObserver = Observer<AlbumDetailViewModel.ViewState> {
+        progressBar.visible = it.isLoading
 
-        observe(viewModel.stateLiveData, ::onStateChange)
-        viewModel.loadData()
-    }
+        nameTextView.text = it.albumName
+        nameTextView.visible = it.albumName.isNotBlank()
 
-    private fun onStateChange(state: AlbumDetailViewModel.ViewState) {
-        progressBar.visible = state.isLoading
+        artistTextView.text = it.artistName
+        artistTextView.visible = it.artistName.isNotBlank()
 
-        nameTextView.text = state.albumName
-        nameTextView.visible = state.albumName.isNotBlank()
-
-        artistTextView.text = state.artistName
-        artistTextView.visible = state.artistName.isNotBlank()
-
-        errorAnimation.visible = state.isError
+        errorAnimation.visible = it.isError
 
         val imageSize = 800
 
-        coverImageView.load(state.coverImageUrl) {
+        coverImageView.load(it.coverImageUrl) {
             size(imageSize, imageSize)
         }
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        observe(viewModel.stateLiveData, stateObserver)
+        viewModel.loadData()
     }
 }

--- a/feature_album/src/main/java/com/igorwojda/showcase/feature/album/presentation/albumlist/AlbumListFragment.kt
+++ b/feature_album/src/main/java/com/igorwojda/showcase/feature/album/presentation/albumlist/AlbumListFragment.kt
@@ -2,6 +2,7 @@ package com.igorwojda.showcase.feature.album.presentation.albumlist
 
 import android.os.Bundle
 import android.view.View
+import androidx.lifecycle.Observer
 import androidx.navigation.fragment.findNavController
 import com.igorwojda.showcase.feature.album.R
 import com.igorwojda.showcase.feature.album.presentation.albumlist.recyclerview.AlbumAdapter
@@ -19,6 +20,12 @@ class AlbumListFragment : BaseContainerFragment() {
     override val layoutResourceId = R.layout.fragment_album_list
 
     private val albumAdapter: AlbumAdapter by instance()
+
+    private val stateObserver = Observer<AlbumListViewModel.ViewState> {
+        albumAdapter.albums = it.albums
+        progressBar.visible = it.isLoading
+        errorAnimation.visible = it.isError
+    }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -41,13 +48,7 @@ class AlbumListFragment : BaseContainerFragment() {
             adapter = albumAdapter
         }
 
-        observe(viewModel.stateLiveData, ::onStateChange)
+        observe(viewModel.stateLiveData, stateObserver)
         viewModel.loadData()
-    }
-
-    private fun onStateChange(state: AlbumListViewModel.ViewState) {
-        albumAdapter.albums = state.albums
-        progressBar.visible = state.isLoading
-        errorAnimation.visible = state.isError
     }
 }

--- a/library_base/src/main/java/com/igorwojda/showcase/library/base/presentation/extension/LiveDataExtensions.kt
+++ b/library_base/src/main/java/com/igorwojda/showcase/library/base/presentation/extension/LiveDataExtensions.kt
@@ -4,6 +4,6 @@ import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.Observer
 
-fun <T> LifecycleOwner.observe(liveData: LiveData<T>, body: (T) -> Unit = {}) {
-    liveData.observe(this, Observer { it?.let { t -> body(t) } })
+fun <T> LifecycleOwner.observe(liveData: LiveData<T>, observer: Observer<T>) {
+    liveData.observe(this, observer)
 }


### PR DESCRIPTION
Using the previous extension (where we pass function reference that is wrapped into observable inside extension) was not the right way.

When navigating back `onViewCreated` method was called making observable re-register because the `onStateChanged` function was wrapped into observable (inside extension).