### PR TITLE
Removed vector drawables

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -22,7 +22,6 @@ android {
         versionCode = AndroidConfig.VERSION_CODE
         versionName = AndroidConfig.VERSION_NAME
         testInstrumentationRunner = AndroidConfig.TEST_INSTRUMENTATION_RUNNER
-        vectorDrawables.useSupportLibrary = AndroidConfig.SUPPORT_LIBRARY_VECTOR_DRAWABLES
 
         buildConfigFieldFromGradleProperty("apiBaseUrl")
         buildConfigFieldFromGradleProperty("apiToken")

--- a/buildSrc/src/main/kotlin/AndroidConfig.kt
+++ b/buildSrc/src/main/kotlin/AndroidConfig.kt
@@ -9,7 +9,6 @@ object AndroidConfig {
 
     const val ID = "com.igorwojda.showcase"
     const val TEST_INSTRUMENTATION_RUNNER = "android.support.test.runner.AndroidJUnitRunner"
-    const val SUPPORT_LIBRARY_VECTOR_DRAWABLES = true
 }
 
 interface BuildType {

--- a/feature_album/build.gradle.kts
+++ b/feature_album/build.gradle.kts
@@ -17,7 +17,6 @@ android {
         versionCode = AndroidConfig.VERSION_CODE
         versionName = AndroidConfig.VERSION_NAME
         testInstrumentationRunner = AndroidConfig.TEST_INSTRUMENTATION_RUNNER
-        vectorDrawables.useSupportLibrary = AndroidConfig.SUPPORT_LIBRARY_VECTOR_DRAWABLES
     }
 
     buildTypes {

--- a/feature_favourite/build.gradle.kts
+++ b/feature_favourite/build.gradle.kts
@@ -17,7 +17,6 @@ android {
         versionCode = AndroidConfig.VERSION_CODE
         versionName = AndroidConfig.VERSION_NAME
         testInstrumentationRunner = AndroidConfig.TEST_INSTRUMENTATION_RUNNER
-        vectorDrawables.useSupportLibrary = AndroidConfig.SUPPORT_LIBRARY_VECTOR_DRAWABLES
     }
 
     buildTypes {

--- a/feature_profile/build.gradle.kts
+++ b/feature_profile/build.gradle.kts
@@ -17,7 +17,6 @@ android {
         versionCode = AndroidConfig.VERSION_CODE
         versionName = AndroidConfig.VERSION_NAME
         testInstrumentationRunner = AndroidConfig.TEST_INSTRUMENTATION_RUNNER
-        vectorDrawables.useSupportLibrary = AndroidConfig.SUPPORT_LIBRARY_VECTOR_DRAWABLES
     }
 
     buildTypes {

--- a/library_base/build.gradle.kts
+++ b/library_base/build.gradle.kts
@@ -16,7 +16,6 @@ android {
         versionCode = AndroidConfig.VERSION_CODE
         versionName = AndroidConfig.VERSION_NAME
         testInstrumentationRunner = AndroidConfig.TEST_INSTRUMENTATION_RUNNER
-        vectorDrawables.useSupportLibrary = AndroidConfig.SUPPORT_LIBRARY_VECTOR_DRAWABLES
     }
 
     buildTypes {

--- a/library_test_utils/build.gradle.kts
+++ b/library_test_utils/build.gradle.kts
@@ -16,7 +16,6 @@ android {
         versionCode = AndroidConfig.VERSION_CODE
         versionName = AndroidConfig.VERSION_NAME
         testInstrumentationRunner = AndroidConfig.TEST_INSTRUMENTATION_RUNNER
-        vectorDrawables.useSupportLibrary = AndroidConfig.SUPPORT_LIBRARY_VECTOR_DRAWABLES
     }
 
     buildTypes {


### PR DESCRIPTION
This flag is only [needed on versions 5.0 and lower](https://developer.android.com/guide/topics/graphics/vector-drawable-resources#vector-drawables-backward-solution). Android 5.0+ has buildin support for vector drawables.