### PR TITLE
Save test results and reports on CircleCI

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -76,6 +76,23 @@ jobs:
       - restore-gradle-cache
       # --stacktrace is just a temporary flag to help with debugging of ConcurrentModificationException that happens occasionally
       - run: ./gradlew testDebugUnitTest --stacktrace
+      - run:
+          name: Save test results
+          command: |
+            mkdir -p ~/junit/
+            find . -type f -regex ".*/build/test-results/.*xml" -exec cp {} ~/junit/ \;
+          when: always
+      - store_test_results:
+          path: ~/junit
+      - run:
+          name: Save test reports
+          command: |
+            mkdir -p ~/reports/
+            cp -R ./app/build/reports/* ~/reports/
+          when: always
+      - store_artifacts:
+          path: ~/reports/
+          destination: reports
 
   build_app:
     description: An executor with sensible defaults for Android Gradle tasks (set with GRADLE_OPTS).

--- a/circle.yml
+++ b/circle.yml
@@ -88,7 +88,9 @@ jobs:
           name: Save test reports
           command: |
             mkdir -p ~/reports/
-            cp -R ./app/build/reports/* ~/reports/
+            cp -R ./feature_album/build/reports/* ~/reports/feature_album
+            cp -R ./feature_favourite/build/reports/* ~/reports/feature_favourite
+            cp -R ./feature_profile/build/reports/* ~/reports/feature_profile
           when: always
       - store_artifacts:
           path: ~/reports/


### PR DESCRIPTION
Hi Igor,

I've modified the unit_test task storing test results and reports on the platform to help debugging in case of an error of the task.