### PR TITLE
Remove explicit Kotlin JVM target

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -63,10 +63,6 @@ android {
         sourceCompatibility = JavaVersion.VERSION_1_8
         targetCompatibility = JavaVersion.VERSION_1_8
     }
-
-    kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_1_8.toString()
-    }
 }
 
 dependencies {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,5 @@
 import com.android.build.gradle.BaseExtension
 import io.gitlab.arturbosch.detekt.Detekt
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
     id(GradlePluginId.DETEKT)
@@ -25,8 +24,6 @@ allprojects {
 
     // Ktlint configuration for sub-projects
     ktlint {
-        // Version of ktlint cmd tool (Ktlint Gradle plugin is just a wrapper for this tool)
-        version.set("0.40.0")
         verbose.set(true)
         android.set(true)
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -120,11 +120,6 @@ fun Project.configureAndroid() {
     }
 }
 
-// JVM target applied to all Kotlin tasks across all sub-projects
-tasks.withType<KotlinCompile> {
-    kotlinOptions.jvmTarget = JavaVersion.VERSION_1_8.toString()
-}
-
 // Target version of the generated JVM bytecode. It is used for type resolution.
 tasks.withType<Detekt> {
     this.jvmTarget = "1.8"

--- a/feature_album/build.gradle.kts
+++ b/feature_album/build.gradle.kts
@@ -36,10 +36,6 @@ android {
         targetCompatibility = JavaVersion.VERSION_1_8
     }
 
-    kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_1_8.toString()
-    }
-
     // Removes the need to mock need to mock classes that may be irrelevant from test perspective
     testOptions {
         unitTests.isReturnDefaultValues = TestOptions.IS_RETURN_DEFAULT_VALUES

--- a/feature_favourite/build.gradle.kts
+++ b/feature_favourite/build.gradle.kts
@@ -36,10 +36,6 @@ android {
         targetCompatibility = JavaVersion.VERSION_1_8
     }
 
-    kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_1_8.toString()
-    }
-
     // Removes the need to mock need to mock classes that may be irrelevant from test perspective
     testOptions {
         unitTests.isReturnDefaultValues = TestOptions.IS_RETURN_DEFAULT_VALUES

--- a/feature_profile/build.gradle.kts
+++ b/feature_profile/build.gradle.kts
@@ -36,10 +36,6 @@ android {
         targetCompatibility = JavaVersion.VERSION_1_8
     }
 
-    kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_1_8.toString()
-    }
-
     // Removes the need to mock need to mock classes that may be irrelevant from test perspective
     testOptions {
         unitTests.isReturnDefaultValues = TestOptions.IS_RETURN_DEFAULT_VALUES

--- a/library_test_utils/build.gradle.kts
+++ b/library_test_utils/build.gradle.kts
@@ -27,10 +27,6 @@ android {
         }
     }
 
-    kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_1_8.toString()
-    }
-
     testOptions {
         unitTests.isReturnDefaultValues = TestOptions.IS_RETURN_DEFAULT_VALUES
     }


### PR DESCRIPTION
Kotlin 1.5 uses JVM Target 1.8 ad default, so the explicit version change is not required anymore