### PR TITLE
Enable Gradle parallel Garbage Collector

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@
 # The setting is particularly useful for tweaking memory settings.
 
 # -------Gradle--------
-org.gradle.jvmargs=-Xmx4g
+org.gradle.jvmargs=-Xmx4g -XX:+UseParallelGC
 org.gradle.daemon=true
 org.gradle.parallel=true
 org.gradle.caching=true


### PR DESCRIPTION
Google recommends enabling parallel JVM garbage collector to speed up builds
// https://developer.android.com/studio/build/optimize-your-build?utm_source=android-studio#configure-gc