### PR TITLE
Update observe extension

### DIFF
--- a/app/src/main/kotlin/com/igorwojda/showcase/base/extension/FragmentExt.kt
+++ b/app/src/main/kotlin/com/igorwojda/showcase/base/extension/FragmentExt.kt
@@ -1,6 +1,9 @@
 package com.igorwojda.showcase.base.extension
 
 import androidx.fragment.app.Fragment
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.Observer
 import androidx.navigation.NavDirections
 import androidx.navigation.NavOptions
 import androidx.navigation.fragment.findNavController
@@ -50,4 +53,8 @@ fun Fragment.canNavigate(): Boolean {
         Timber.d("May not navigate: current destination is not the current fragment.")
         false
     }
+}
+
+fun <T> Fragment.observe(liveData: LiveData<T>, observer: Observer<T>) {
+    liveData.observe(viewLifecycleOwner, observer)
 }

--- a/app/src/main/kotlin/com/igorwojda/showcase/base/presentation/extension/LiveDataExtensions.kt
+++ b/app/src/main/kotlin/com/igorwojda/showcase/base/presentation/extension/LiveDataExtensions.kt
@@ -1,9 +1,0 @@
-package com.igorwojda.showcase.base.presentation.extension
-
-import androidx.lifecycle.LifecycleOwner
-import androidx.lifecycle.LiveData
-import androidx.lifecycle.Observer
-
-fun <T> LifecycleOwner.observe(liveData: LiveData<T>, observer: Observer<T>) {
-    liveData.observe(this, observer)
-}

--- a/feature_album/src/main/kotlin/com/igorwojda/showcase/feature/album/presentation/albumdetail/AlbumDetailFragment.kt
+++ b/feature_album/src/main/kotlin/com/igorwojda/showcase/feature/album/presentation/albumdetail/AlbumDetailFragment.kt
@@ -5,7 +5,7 @@ import android.view.View
 import androidx.lifecycle.Observer
 import coil.load
 import com.igorwojda.showcase.base.delegate.viewBinding
-import com.igorwojda.showcase.base.presentation.extension.observe
+import com.igorwojda.showcase.base.extension.observe
 import com.igorwojda.showcase.base.presentation.extension.visible
 import com.igorwojda.showcase.base.presentation.fragment.InjectionFragment
 import com.igorwojda.showcase.feature.album.R

--- a/feature_album/src/main/kotlin/com/igorwojda/showcase/feature/album/presentation/albumlist/AlbumListFragment.kt
+++ b/feature_album/src/main/kotlin/com/igorwojda/showcase/feature/album/presentation/albumlist/AlbumListFragment.kt
@@ -4,7 +4,7 @@ import android.os.Bundle
 import android.view.View
 import androidx.lifecycle.Observer
 import com.igorwojda.showcase.base.delegate.viewBinding
-import com.igorwojda.showcase.base.presentation.extension.observe
+import com.igorwojda.showcase.base.extension.observe
 import com.igorwojda.showcase.base.presentation.extension.visible
 import com.igorwojda.showcase.base.presentation.fragment.InjectionFragment
 import com.igorwojda.showcase.feature.album.R

--- a/feature_album/src/main/kotlin/com/igorwojda/showcase/feature/album/presentation/albumlist/recyclerview/AlbumAdapter.kt
+++ b/feature_album/src/main/kotlin/com/igorwojda/showcase/feature/album/presentation/albumlist/recyclerview/AlbumAdapter.kt
@@ -6,9 +6,7 @@ import androidx.recyclerview.widget.RecyclerView
 import coil.load
 import coil.transform.RoundedCornersTransformation
 import com.igorwojda.showcase.base.delegate.observer
-import com.igorwojda.showcase.base.presentation.extension.hide
 import com.igorwojda.showcase.base.presentation.extension.setOnDebouncedClickListener
-import com.igorwojda.showcase.base.presentation.extension.show
 import com.igorwojda.showcase.feature.album.R
 import com.igorwojda.showcase.feature.album.databinding.FragmentAlbumListItemBinding
 import com.igorwojda.showcase.feature.album.domain.model.Album


### PR DESCRIPTION
Comply with AS warning
`viewLifecycleOwner` must be used instead of `this`, because the app may crash in some cases

![image](https://user-images.githubusercontent.com/530122/128755807-8c79e3e3-6094-437e-ae23-1f93d5788ad4.png)
