### PR TITLE
Define key for list of Albums

### DIFF
--- a/feature_album/src/main/kotlin/com/igorwojda/showcase/feature/album/domain/model/Album.kt
+++ b/feature_album/src/main/kotlin/com/igorwojda/showcase/feature/album/domain/model/Album.kt
@@ -12,5 +12,8 @@ internal data class Album(
     val tracks: List<Track>? = null,
     val tags: List<Tag>? = null,
 ) {
+
+    val id: String = "$artist - $name"
+
     fun getDefaultImageUrl() = images.firstOrNull { it.size == ImageSize.EXTRA_LARGE }?.url
 }

--- a/feature_album/src/main/kotlin/com/igorwojda/showcase/feature/album/presentation/screen/albumlist/AlbumListFragment.kt
+++ b/feature_album/src/main/kotlin/com/igorwojda/showcase/feature/album/presentation/screen/albumlist/AlbumListFragment.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.material3.ElevatedCard
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.runtime.Composable
@@ -170,9 +171,7 @@ private fun PhotoGrid(albums: List<Album>, viewModel: AlbumListViewModel) {
         columns = GridCells.Adaptive(Dimen.imageSize),
         contentPadding = PaddingValues(Dimen.screenContentPadding)
     ) {
-        items(albums.size) { index ->
-            val album = albums[index]
-
+        items(items = albums) { album ->
             ElevatedCard(
                 modifier = Modifier
                     .padding(Dimen.spaceS)

--- a/feature_album/src/main/kotlin/com/igorwojda/showcase/feature/album/presentation/screen/albumlist/AlbumListFragment.kt
+++ b/feature_album/src/main/kotlin/com/igorwojda/showcase/feature/album/presentation/screen/albumlist/AlbumListFragment.kt
@@ -171,7 +171,7 @@ private fun PhotoGrid(albums: List<Album>, viewModel: AlbumListViewModel) {
         columns = GridCells.Adaptive(Dimen.imageSize),
         contentPadding = PaddingValues(Dimen.screenContentPadding)
     ) {
-        items(items = albums) { album ->
+        items(items = albums, key = { it.id }) { album ->
             ElevatedCard(
                 modifier = Modifier
                     .padding(Dimen.spaceS)


### PR DESCRIPTION
## Define key for list of Albums

In this PR I've added `key` param for `items` function in AlbumListScreen Composable.
Small change.

## Why?
We should always define key for any type of list. 

More information can be found in documentation: https://developer.android.com/jetpack/compose/lists#item-keys