### PR TITLE
Upd Renovate Config

### DIFF
--- a/README.md
+++ b/README.md
@@ -413,20 +413,18 @@ Other high-quality projects will help you to find solutions that work for your p
   using `findNavController()` ([ISSUE-142847973](https://issuetracker.google.com/issues/142847973),
   [STACKOVERFLOW-59275182](https://stackoverflow.com/questions/59275009/fragmentcontainerview-using-findnavcontroller/59275182))
 - Mockk is unable to mock some methods with implicit `continuation`
-  parameter in the `AlbumListViewModelTest` class ([Issue-957](https://github.com/mockk/mockk/issues/957))
-- Jetpack compose compiler depends
-  on [specific Kotlin version](https://developer.android.com/jetpack/androidx/releases/compose-kotlin). Kotlin upgrade
-  is blocked until compose catches up (error: This version (x.x.x) of the Compose Compiler requires Kotlin version x.x.x
-  but you appear to be using Kotlin version y.y.y which is not known to be compatible)  (disabled in Renovate)
-- KSP depends on
-  [specific Kotlin version](https://repo.maven.apache.org/maven2/com/google/devtools/ksp/symbol-processing-gradle-plugin/)
-  so, dependencies must be upgraded together  (disabled in Renovate).
-- `Mockk` can;t find an answer for suspended function, so test in the `AlbumDetailViewModelTest` was disabled
+  parameter in the `AlbumListViewModelTest` class ([Issue-957](https://github.com/mockk/mockk/issues/957)), , so test
+  in the `AlbumDetailViewModelTest` was disabled
+- Automatic Kotlin upgrade is disabled in Renovate, because these dependencies have to be updated together with Kotlin:
+  until:
+  - [Jetpack compose compiler](https://developer.android.com/jetpack/androidx/releases/compose-kotlin)
+  - [KSP](https://repo.maven.apache.org/maven2/com/google/devtools/ksp/symbol-processing-gradle-plugin/)
 - [Dynamic feature module](https://developer.android.com/studio/projects/dynamic-delivery) is not supported by
   `ANDROID_TEST_USES_UNIFIED_TEST_PLATFORM` yet.
 - ktlint `FileName` rule has to be disabled, because it is not compatible with fie contain a single extension
   [ISSUE-1657](https://github.com/pinterest/ktlint/issues/1657)
-- Delegate import is not provided when a variable has the same name as Delegate ([KTIJ-17403](https://youtrack.jetbrains.com/issue/KTIJ-17403))
+- Delegate import is not provided when a variable has the same name as
+  Delegate ([KTIJ-17403](https://youtrack.jetbrains.com/issue/KTIJ-17403))
 - `androidx.compose.runtime.getValue` and `androidx.compose.runtime.setValue` imports are can't be resolved
   automatically - they had to be added manually [KTIJ-23200](https://youtrack.jetbrains.com/issue/KTIJ-23200)
 - [ktlint import-ordering](https://github.com/pinterest/ktlint/blob/master/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/ImportOrderingRule.kt)

--- a/renovate.json
+++ b/renovate.json
@@ -20,15 +20,17 @@
     },
     {
       "matchPackagePatterns": [
-        "^org.jetbrains.kotlin.android",
-        "^org.jetbrains.kotlin:kotlin-reflect",
-        "^com.google.devtools.ksp",
-        "^androidx.compose.compiler",
-        "androidx.compose.material3:material3",
         "androidx.compose.ui:ui",
         "androidx.compose.ui:ui-tooling-preview"
       ],
-      "groupName": "kotlin"
+      "groupName": "androidx compose ui updates"
+    },
+    {
+      "matchPackageNames": [
+        "org.jetbrains.kotlin.*",
+        "com.google.devtools.ksp"
+      ],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
- Don't automatically update kotlin related dependencies, because `kotlinSymbolProcessing` and `kotlinCompilerExtensionVersion` have to be upgraded together with Kotlin. The `kotlinSymbolProcessing` is usually available a bit later than Kotlin and the proper version of `kotlinCompilerExtensionVersion` can't be determined by renovate
- Update compose UI deps together