### PR TITLE
Bring project up to date

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,6 +1,7 @@
 import com.android.build.api.dsl.ApplicationDefaultConfig
 import java.util.Locale
-
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 plugins {
     id("local.app")
 }
@@ -13,18 +14,17 @@ android {
 
     compileSdk = libs.findVersion("compileSdk").get().toString().toInt()
 
-    defaultConfig {
-        minSdk = libs.findVersion("minSdk").get().toString().toInt()
-
-        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
-    }
 
     defaultConfig {
         applicationId = "com.igorwojda.showcase"
 
+        minSdk = libs.findVersion("minSdk").get().toString().toInt()
+        targetSdk = libs.findVersion("targetSdk").get().toString().toInt()
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+
         versionCode = 1
         versionName = "0.0.1" // SemVer (Major.Minor.Patch)
-        minSdk = 28
+
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 
         multiDexEnabled = true
@@ -44,24 +44,21 @@ android {
         }
     }
 
-    @Suppress("UnstableApiUsage")
     buildFeatures {
         viewBinding = true
         buildConfig = true
         compose = true
     }
 
-    composeOptions {
-        kotlinCompilerExtensionVersion = libs.findVersion("kotlinCompilerExtensionVersion").get().toString()
-    }
-
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_11
-        targetCompatibility = JavaVersion.VERSION_11
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
 
-    kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_11.toString()
+    kotlin {
+        compilerOptions {
+            jvmTarget = JvmTarget.JVM_17
+        }
     }
 
     @Suppress("UnstableApiUsage")
@@ -71,7 +68,7 @@ android {
 }
 
 dependencies {
-    // Syntax utilizes Gradle TYPESAFE_PROJECT_ACCESSORS feature
+    // "projects." Syntax utilizes Gradle TYPESAFE_PROJECT_ACCESSORS feature
     implementation(projects.featureAlbum)
     implementation(projects.featureProfile)
     implementation(projects.featureFavourite)

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -13,6 +13,7 @@ dependencies {
     implementation(plugin(libs.plugins.detekt))
     implementation(plugin(libs.plugins.junit5Android))
     implementation(plugin(libs.plugins.safeArgs))
+    implementation(plugin(libs.plugins.compose))
 }
 
 kotlin {

--- a/buildSrc/src/main/kotlin/local.app.gradle.kts
+++ b/buildSrc/src/main/kotlin/local.app.gradle.kts
@@ -3,4 +3,5 @@ plugins {
     id("local.kotlin")
     id("local.spotless")
     id("com.google.devtools.ksp")
+    id("org.jetbrains.kotlin.plugin.compose")
 }

--- a/buildSrc/src/main/kotlin/local.library.gradle.kts
+++ b/buildSrc/src/main/kotlin/local.library.gradle.kts
@@ -1,9 +1,12 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
 plugins {
     id("com.android.library")
     id("local.kotlin")
     id("local.test")
     id("androidx.navigation.safeargs.kotlin")
     id("com.google.devtools.ksp")
+    id("org.jetbrains.kotlin.plugin.compose")
 }
 
 android {
@@ -20,24 +23,21 @@ android {
         consumerProguardFiles("consumer-rules.pro")
     }
 
-    @Suppress("UnstableApiUsage")
     buildFeatures {
         viewBinding = true
         buildConfig = true
         compose = true
     }
 
-    composeOptions {
-        kotlinCompilerExtensionVersion = libs.findVersion("kotlinCompilerExtensionVersion").get().toString()
-    }
-
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_11
-        targetCompatibility = JavaVersion.VERSION_11
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
 
-    kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_11.toString()
+    kotlin {
+        compilerOptions {
+            jvmTarget = JvmTarget.JVM_17
+        }
     }
 
     @Suppress("UnstableApiUsage")

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,40 +1,38 @@
 [versions]
-kotlin = "1.9.24"
+kotlin = "2.2.0"
 
 # KSP depends on specific Kotlin version, so it must be upgraded together with Kotlin (disabled in Renovate)
 # https://repo.maven.apache.org/maven2/com/google/devtools/ksp/symbol-processing-gradle-plugin/
-kotlinSymbolProcessing = "1.9.24-1.0.20"
+kotlinSymbolProcessing = "2.2.0-2.0.2"
 
-# Compose compiler depends on specific Kotlin version, so it must be upgraded together with Kotlin (disabled in Renovate)
-# https://developer.android.com/jetpack/androidx/releases/compose-kotlin
-kotlinCompilerExtensionVersion = "1.5.14"
+# Android SDK versions are marked as unused, however these are used in the `build.gradle.kts` files
+compileSdk = "36"
+minSdk = "28"
+targetSdk = "36"
 
-compileSdk = "35"
-minSdk = "26"
-
-navigation = "2.8.7"
+navigation = "2.9.2"
 testLogger = "3.2.0"
-coroutines = "1.10.1"
-retrofit = "2.11.0"
+coroutines = "1.10.2"
+retrofit = "3.0.0"
 okhttp = "4.12.0"
-koin = "3.5.6"
+koin = "4.0.4"
 coil = "2.7.0"
-lifecycle = "2.8.7"
-room = "2.6.1"
-serializationJson = "1.8.0"
+lifecycle = "2.9.2"
+room = "2.7.2"
+serializationJson = "1.9.0"
 kotlinxSerializationConverter = "1.0.0"
 viewBindingPropertyDelegate = "1.5.9"
 timber = "5.0.1"
-constraintLayout = "2.2.0"
-appCompat = "1.7.0"
+constraintLayout = "2.2.1"
+appCompat = "1.7.1"
 recyclerView = "1.4.0"
-compose = "1.7.8"
-materialCompose = "1.3.1"
+compose = "1.8.3"
+materialCompose = "1.3.2"
 material = "1.12.0"
 lottie = "6.6.2"
 playCore = "1.10.3"
-coreKtx = "1.15.0"
-fragmentKtx = "1.8.6"
+coreKtx = "1.16.0"
+fragmentKtx = "1.8.8"
 # Info https://google.github.io/accompanist/flowlayout/
 # Repo https://oss.sonatype.org/content/repositories/snapshots/com/google/accompanist/accompanist-flowlayout/
 accompanistFlowLayout = "0.32.0"
@@ -46,11 +44,11 @@ androidGradlePlugin = "8.8.1"
 
 # Test versionsandroid-junit5-plugin-dsl
 
-junit = "5.12.0"
+junit = "5.12.2"
 androidJUnit5 = "1.11.3.0"
 kluent = "1.73"
 testRunner = "1.6.2"
-mockk = "1.13.16"
+mockk = "1.14.5"
 espresso = "3.6.1"
 coreTesting = "2.2.0"
 
@@ -66,6 +64,7 @@ spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }
 safeArgs = { id = "androidx.navigation.safeargs.kotlin", version.ref = "navigation" }
 junit5Android = { id = "de.mannodermaus.android-junit5", version.ref = "androidJUnit5" }
 testLogger = { id = "com.adarshr.test-logger", version.ref = "testLogger" }
+compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 
 [libraries]
 kotlin = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref = "kotlin" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,15 +1,15 @@
 [versions]
-kotlin = "1.9.25"
+kotlin = "1.9.24"
 
 # KSP depends on specific Kotlin version, so it must be upgraded together with Kotlin (disabled in Renovate)
 # https://repo.maven.apache.org/maven2/com/google/devtools/ksp/symbol-processing-gradle-plugin/
-kotlinSymbolProcessing = "1.9.25-1.0.20"
+kotlinSymbolProcessing = "1.9.24-1.0.20"
 
 # Compose compiler depends on specific Kotlin version, so it must be upgraded together with Kotlin (disabled in Renovate)
 # https://developer.android.com/jetpack/androidx/releases/compose-kotlin
-kotlinCompilerExtensionVersion = "1.5.4"
+kotlinCompilerExtensionVersion = "1.5.14"
 
-compileSdk = "34"
+compileSdk = "35"
 minSdk = "26"
 
 navigation = "2.8.7"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
# Changes
- Update `compileSdk` to `36`
- Update `minSdk` to  `26` 
- Add `targetSdk` (to remove [warnig after install](https://stackoverflow.com/questions/73517346/this-app-was-built-for-an-older-version-of-android-and-doesnt-include-the-lates))
- Removed some `@Suppress("UnstableApiUsage")` annotations
- Upd Java to `17`
- Replace deprectaed `kotlinOptions`
- Remove uneeded `kotlinCompilerExtensionVersion`

# Update Dependencies
- Gradle
- Kotlin
- Konsist
- Retrofit
- Mockk
- JUnit
- Compose Navigation
- Coroutines
- Koin
- Lifecycle
- Room
- Serialization
- Constraint Layout
- App Compat
- Compose
- Compose Material
- Core ktx
- Fragment Ktx
