### PR TITLE
Add Java Config

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,7 +1,7 @@
 
 import com.android.build.api.dsl.ApplicationDefaultConfig
-import java.util.Locale
 import config.JavaConfig
+import java.util.Locale
 
 plugins {
     id("local.app")

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,7 +1,7 @@
 
 import com.android.build.api.dsl.ApplicationDefaultConfig
 import java.util.Locale
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import config.JavaConfig
 
 plugins {
     id("local.app")
@@ -70,13 +70,13 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
+        sourceCompatibility = JavaConfig.javaVersion
+        targetCompatibility = JavaConfig.javaVersion
     }
 
     kotlin {
         compilerOptions {
-            jvmTarget = JvmTarget.JVM_17
+            jvmTarget = JavaConfig.jvmTarget
         }
     }
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -90,6 +90,8 @@ dependencies {
     implementation(projects.feature.album)
     implementation(projects.feature.profile)
     implementation(projects.feature.favourite)
+
+    implementation(platform(libs.compose.bom))
     implementation(libs.navigation.compose)
 }
 

--- a/buildSrc/src/main/kotlin/config/JavaConfig.kt
+++ b/buildSrc/src/main/kotlin/config/JavaConfig.kt
@@ -1,0 +1,28 @@
+package config
+
+import org.gradle.api.JavaVersion
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
+/**
+ * Centralized place for Java/Kotlin version configuration
+ *
+ * ```kotlin
+ * compileOptions {
+ *     sourceCompatibility = JavaConfig.javaVersion
+ *     targetCompatibility = JavaConfig.javaVersion
+ * }
+ *
+ * kotlin {
+ *     compilerOptions {
+ *         jvmTarget = JavaConfig.jvmTarget
+ *     }
+ * }
+ * ```
+ */
+object JavaConfig {
+    private const val VERSION_STRING = "17"
+
+    val javaVersion: JavaVersion = JavaVersion.VERSION_17
+    val jvmTarget: JvmTarget = JvmTarget.JVM_17
+    val versionString: String = VERSION_STRING
+}

--- a/buildSrc/src/main/kotlin/config/JavaConfig.kt
+++ b/buildSrc/src/main/kotlin/config/JavaConfig.kt
@@ -24,5 +24,4 @@ object JavaConfig {
 
     val javaVersion: JavaVersion = JavaVersion.VERSION_17
     val jvmTarget: JvmTarget = JvmTarget.JVM_17
-    val versionString: String = VERSION_STRING
 }

--- a/buildSrc/src/main/kotlin/config/JavaConfig.kt
+++ b/buildSrc/src/main/kotlin/config/JavaConfig.kt
@@ -20,8 +20,6 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
  * ```
  */
 object JavaConfig {
-    private const val VERSION_STRING = "17"
-
     val javaVersion: JavaVersion = JavaVersion.VERSION_17
     val jvmTarget: JvmTarget = JvmTarget.JVM_17
 }

--- a/buildSrc/src/main/kotlin/local.library.gradle.kts
+++ b/buildSrc/src/main/kotlin/local.library.gradle.kts
@@ -1,4 +1,4 @@
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import config.JavaConfig
 
 plugins {
     id("com.android.library")
@@ -39,13 +39,13 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
+        sourceCompatibility = JavaConfig.javaVersion
+        targetCompatibility = JavaConfig.javaVersion
     }
 
     kotlin {
         compilerOptions {
-            jvmTarget = JvmTarget.JVM_17
+            jvmTarget = JavaConfig.jvmTarget
         }
     }
 

--- a/feature/base/build.gradle.kts
+++ b/feature/base/build.gradle.kts
@@ -25,6 +25,8 @@ dependencies {
     api(libs.bundles.navigation)
     api(libs.bundles.lifecycle)
     api(libs.bundles.room)
+
+    implementation(platform(libs.compose.bom))
     api(libs.bundles.compose)
 
     testImplementation(projects.library.testUtils)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -25,6 +25,7 @@ timber = "5.0.1"
 constraint-layout = "2.2.1"
 app-compat = "1.7.1"
 compose = "1.9.0"
+compose-bom = "2025.06.01"
 material-compose = "1.3.2"
 material = "1.13.0"
 lottie = "6.6.7"
@@ -98,6 +99,7 @@ junit-jupiter-api = { module = "org.junit.jupiter:junit-jupiter-api", version.re
 junit-jupiter-engine = { module = "org.junit.jupiter:junit-jupiter-engine", version.ref = "junit-jupiter" }
 junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher", version = "1.13.4" }
 navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "navigation" }
+compose-bom = { module = "androidx.compose:compose-bom", version.ref = "compose-bom" }
 
 [bundles]
 retrofit = [

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,6 +5,8 @@ kotlin = "2.2.10"
 # https://repo.maven.apache.org/maven2/com/google/devtools/ksp/symbol-processing-gradle-plugin/
 kotlin-symbol-processing = "2.2.10-2.0.2"
 
+# Java and JVM Versions are stored in buildSrc/src/main/kotlin/config/JavaConfig.kt
+
 # Android SDK versions are marked as unused, however these are used in the `build.gradle.kts` files
 compile-sdk = "36"
 min-sdk = "28"
@@ -22,7 +24,6 @@ room = "2.7.2"
 serialization-json = "1.9.0"
 kotlinx-serialization-converter = "1.0.0"
 timber = "5.0.1"
-constraint-layout = "2.2.1"
 app-compat = "1.7.1"
 compose = "1.9.0"
 compose-bom = "2025.06.01"


### PR DESCRIPTION
Centralize Java/Kotlin version configuration

This commit introduces a `JavaConfig` object in `buildSrc` to manage Java and Kotlin versions consistently across the project.

The `app/build.gradle.kts` and `buildSrc/src/main/kotlin/local.library.gradle.kts` files were updated to use this new configuration.

Additionally, an unused `constraint-layout` dependency was removed from `gradle/libs.versions.toml`.