### PR TITLE
Standardize Java/Kotlin versions

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -70,13 +70,13 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility = JavaConfig.javaVersion
-        targetCompatibility = JavaConfig.javaVersion
+        sourceCompatibility = JavaConfig.JAVA_VERSION
+        targetCompatibility = JavaConfig.JAVA_VERSION
     }
 
     kotlin {
         compilerOptions {
-            jvmTarget = JavaConfig.jvmTarget
+            jvmTarget = JavaConfig.JVM_TARGET
         }
     }
 

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -16,6 +16,7 @@ dependencies {
 }
 
 kotlin {
+    // Version value should match JavaConfig.jvmToolchainVersion
     jvmToolchain(17)
 }
 

--- a/buildSrc/src/main/kotlin/config/JavaConfig.kt
+++ b/buildSrc/src/main/kotlin/config/JavaConfig.kt
@@ -8,18 +8,23 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
  *
  * ```kotlin
  * compileOptions {
- *     sourceCompatibility = JavaConfig.javaVersion
- *     targetCompatibility = JavaConfig.javaVersion
+ *     sourceCompatibility = JavaConfig.JAVA_VERSION
+ *     targetCompatibility = JavaConfig.JAVA_VERSION
  * }
  *
  * kotlin {
  *     compilerOptions {
  *         jvmTarget = JavaConfig.jvmTarget
  *     }
+ *     jvmToolchain(JavaConfig.jvmToolchainVersion)
  * }
  * ```
  */
 object JavaConfig {
-    val javaVersion: JavaVersion = JavaVersion.VERSION_17
-    val jvmTarget: JvmTarget = JvmTarget.JVM_17
+    // // Version value should match version in buildSrc/build.gradle.kts
+    private const val VERSION = 17
+
+    val JAVA_VERSION: JavaVersion = JavaVersion.VERSION_17
+    val JVM_TARGET: JvmTarget = JvmTarget.JVM_17
+    const val JVM_TOOLCHAIN_VERSION: Int = VERSION
 }

--- a/buildSrc/src/main/kotlin/kotlin-convention.gradle.kts
+++ b/buildSrc/src/main/kotlin/kotlin-convention.gradle.kts
@@ -1,8 +1,10 @@
+import config.JavaConfig
+
 plugins {
     id("org.jetbrains.kotlin.android")
     id("org.jetbrains.kotlin.plugin.serialization")
 }
 
 kotlin {
-    jvmToolchain(17)
+    jvmToolchain(JavaConfig.JVM_TOOLCHAIN_VERSION)
 }

--- a/buildSrc/src/main/kotlin/library-convention.gradle.kts
+++ b/buildSrc/src/main/kotlin/library-convention.gradle.kts
@@ -39,13 +39,13 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility = JavaConfig.javaVersion
-        targetCompatibility = JavaConfig.javaVersion
+        sourceCompatibility = JavaConfig.JAVA_VERSION
+        targetCompatibility = JavaConfig.JAVA_VERSION
     }
 
     kotlin {
         compilerOptions {
-            jvmTarget = JavaConfig.jvmTarget
+            jvmTarget = JavaConfig.JVM_TARGET
         }
     }
 


### PR DESCRIPTION
Standardizes the Java and Kotlin versions used across the project by:
- Adding a `JVM_TOOLCHAIN_VERSION` constant in `JavaConfig.kt`.
- Updating `buildSrc/build.gradle.kts` and `kotlin-convention.gradle.kts` to use this constant for the JVM toolchain version.
- Updating usages of `JavaConfig.javaVersion` and `JavaConfig.jvmTarget` to `JavaConfig.JAVA_VERSION` and `JavaConfig.JVM_TARGET` respectively in module-level build scripts.