### PR TITLE
Fix Build Warning

### DIFF
--- a/buildLogic/src/main/kotlin/com/igorwojda/showcase/buildlogic/KotlinConventionPlugin.kt
+++ b/buildLogic/src/main/kotlin/com/igorwojda/showcase/buildlogic/KotlinConventionPlugin.kt
@@ -20,8 +20,8 @@ class KotlinConventionPlugin : Plugin<Project> {
             tasks.withType<KotlinCompile>().configureEach {
                 compilerOptions {
                     freeCompilerArgs.addAll(
-                                    // Fix for https://youtrack.jetbrains.com/issue/KT-73255: set default annotation target
-                        "-Xannotation-default-target=param-property"
+                        // Fix for https://youtrack.jetbrains.com/issue/KT-73255: set default annotation target
+                        "-Xannotation-default-target=param-property",
                     )
                 }
             }

--- a/buildLogic/src/main/kotlin/com/igorwojda/showcase/buildlogic/KotlinConventionPlugin.kt
+++ b/buildLogic/src/main/kotlin/com/igorwojda/showcase/buildlogic/KotlinConventionPlugin.kt
@@ -20,7 +20,11 @@ class KotlinConventionPlugin : Plugin<Project> {
             tasks.withType<KotlinCompile>().configureEach {
                 compilerOptions {
                     freeCompilerArgs.addAll(
-                        // Fix for https://youtrack.jetbrains.com/issue/KT-73255: set default annotation target
+                        /*
+                        This ensures annotations on data class constructor parameters are applied to both
+                        the parameter and the backing field, preventing future breaking changes.
+                        See https://youtrack.jetbrains.com/issue/KT-73255: for more details.
+                         */
                         "-Xannotation-default-target=param-property",
                     )
                 }

--- a/buildLogic/src/main/kotlin/com/igorwojda/showcase/buildlogic/KotlinConventionPlugin.kt
+++ b/buildLogic/src/main/kotlin/com/igorwojda/showcase/buildlogic/KotlinConventionPlugin.kt
@@ -3,7 +3,9 @@ package com.igorwojda.showcase.buildlogic
 import com.igorwojda.showcase.buildlogic.config.JavaBuildConfig
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.kotlin.dsl.withType
 import org.jetbrains.kotlin.gradle.dsl.kotlinExtension
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 class KotlinConventionPlugin : Plugin<Project> {
     override fun apply(target: Project) {
@@ -14,6 +16,15 @@ class KotlinConventionPlugin : Plugin<Project> {
             }
 
             kotlinExtension.jvmToolchain(JavaBuildConfig.JVM_TOOLCHAIN_VERSION)
+
+            tasks.withType<KotlinCompile>().configureEach {
+                compilerOptions {
+                    freeCompilerArgs.addAll(
+                                    // Fix for https://youtrack.jetbrains.com/issue/KT-73255: set default annotation target
+                        "-Xannotation-default-target=param-property"
+                    )
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
```
Fix w: file:///Users/igorwojda/StudioProjects/android-showcase/app/src/main/kotlin/com/igorwojda/showcase/app/presentation/BottomNavigationBar.kt:91:5 
This annotation is currently applied to the value parameter only, but in the future it will also be applied to field. 
To opt in to applying to both value parameter and field, add '-Xannotation-default-target=param-property' to your compiler arguments.

To keep applying to the value parameter only, use the '@param:' annotation target. See https://youtrack.jetbrains.com/issue/KT-73255 for more details.
```